### PR TITLE
Added nan checking for magnetometer message.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,8 @@ find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs std_msgs tf)
 
 catkin_package()
 
+add_definitions(-std=c++11)
+
 include_directories(include
   ${catkin_INCLUDE_DIRS}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,9 @@ find_package(catkin REQUIRED COMPONENTS geometry_msgs sensor_msgs std_msgs tf)
 
 catkin_package()
 
-add_definitions(-std=c++11)
+if(NOT WIN32)
+  set_directory_properties(PROPERTIES COMPILE_OPTIONS "-std=c++11")
+endif()
 
 include_directories(include
   ${catkin_INCLUDE_DIRS}

--- a/src/imu_compass.cpp
+++ b/src/imu_compass.cpp
@@ -23,6 +23,8 @@ CPP file for IMU Compass Class that combines gyroscope and magnetometer data to 
 */
 
 #include "imu_compass/imu_compass.h"
+// For isnan()
+#include "boost/math/special_functions/fpclassify.hpp"
 
 double magn(tf::Vector3 a) {
       return sqrt(a.x()*a.x() + a.y()*a.y() + a.z()*a.z());
@@ -133,6 +135,13 @@ void IMUCompass::declCallback(const std_msgs::Float32& data) {
 void IMUCompass::magCallback(const geometry_msgs::Vector3StampedConstPtr& data) {
   geometry_msgs::Vector3 imu_mag = data->vector;
   geometry_msgs::Vector3 imu_mag_transformed;
+
+  // Check for nans and bail
+  if ( boost::math::isnan(data->vector.x) ||
+       boost::math::isnan(data->vector.y) ||
+       boost::math::isnan(data->vector.z) ) {
+    return;
+  }
 
   imu_mag.x = data->vector.x;
   imu_mag.y = data->vector.y;

--- a/src/imu_compass.cpp
+++ b/src/imu_compass.cpp
@@ -23,8 +23,6 @@ CPP file for IMU Compass Class that combines gyroscope and magnetometer data to 
 */
 
 #include "imu_compass/imu_compass.h"
-// For isnan()
-#include "boost/math/special_functions/fpclassify.hpp"
 
 double magn(tf::Vector3 a) {
       return sqrt(a.x()*a.x() + a.y()*a.y() + a.z()*a.z());
@@ -137,9 +135,9 @@ void IMUCompass::magCallback(const geometry_msgs::Vector3StampedConstPtr& data) 
   geometry_msgs::Vector3 imu_mag_transformed;
 
   // Check for nans and bail
-  if ( boost::math::isnan(data->vector.x) ||
-       boost::math::isnan(data->vector.y) ||
-       boost::math::isnan(data->vector.z) ) {
+  if ( std::isnan(data->vector.x) ||
+       std::isnan(data->vector.y) ||
+       std::isnan(data->vector.z) ) {
     return;
   }
 


### PR DESCRIPTION
An IMU that I was using (Phidgets GeoSpatial, using `phidgets_imu` driver) would spit out NaN's often, which would result in the orientation being created by `imu_compass` to be all NaNs. 

This change checks to see if incoming NaNs occur, and to do nothing when they are encountered. 
